### PR TITLE
create-a-new-page

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -9,3 +9,10 @@ export const ThickNavPage = styled.div`
   margin: 65px 150px 110px 150px;
   min-height: 50vh;
 `;
+
+export const ThickNavTwoColumnsPage = styled.div`
+  display: flex;
+  margin-top: 65px;
+  height: calc(100vh - 65px);
+  width: 100%;
+`


### PR DESCRIPTION
註冊登入、登入、註冊頁面都不需要左右和下方的 margin，沒有合適的 page 可以使用，所以新建 ThickNavTwoColumnsPage
![image](https://user-images.githubusercontent.com/60566603/101334258-9af4ca00-38b2-11eb-953e-e396471e2cfa.png)
